### PR TITLE
Prevented multiple votes in DB

### DIFF
--- a/api/routers/votes/votesStore.js
+++ b/api/routers/votes/votesStore.js
@@ -18,18 +18,24 @@ async function vote(topicId, candidateName, login, isVote) {
 
     const topicVotesCache = cache[topicId];
 
+    const voteItem = topicVotesCache.find(v => v.login === login && v.candidateName === candidateName);
+
     if (isVote) {
-        // Save to Mongo
-        const voteItem = new Vote({ topicId, candidateName, login });
-        await voteItem.save();
+        if (!voteItem) {
 
-        // Save to Cache
-        topicVotesCache.push(voteItem);
+            const voteItem = new Vote({topicId, candidateName, login});
+
+            // Save to Cache
+            topicVotesCache.push(voteItem);
+
+            // Save to Mongo
+            try {
+                await voteItem.save();
+            } catch (err) {
+                topicVotesCache.splice(topicVotesCache.indexOf(voteItem), 1);
+            }
+        }
     } else {
-        const voteItem = topicVotesCache.find(v =>
-            v.login === login
-            && v.candidateName === candidateName);
-
         if (voteItem) {
             // Remove from Mongo
             await voteItem.remove();


### PR DESCRIPTION
**Why:** I got a strange behavior:
1) Opened page with particular topic in case to vote http://localhost:3000/#/vote/some-vote-id 
2) F12 -> Network -> Slow 3g -> Refresh page
3) There is different render stages. Firstly nothing, then "loading...", then list with candidates BUT without votes. And if I click thumbs-up icon several times on this stage for one candidate, then all this requests sends via socket to the server. Server takes them and runs function vote.
`function vote(topicId, candidateName, login, isVote) {...}`
Server runs this function several times (depends on how much you clicked)
- `vote( "topic-id", "some-candidate", "Sergei_Kalachev", true)`
- `vote( "topic-id", "some-candidate", "Sergei_Kalachev", true)`
- `vote( "topic-id", "some-candidate", "Sergei_Kalachev", true)`

And each of them creates a record in the DB. I changed code, so it checks if the record already exists. If so then we do nothing. I also pushed vote firstly to the cache, because there is a delay if we write to DB. This delay can cause multiple votes (just try to repeat first three steps).

I used try-catch in purpose to delete form cache if there will error occurred during writing process to DB. Method save() can accept a callback with error, so we have two options: callback or try-catch. I choose try-catch. With callback it could be something like this:
`await voteItem.save( (err) => {
    if (err){
      topicVotesCache.splice(topicVotesCache.indexOf(voteItem), 1);
      }
});`